### PR TITLE
Fix express.json() body size limit for large payloads

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ const transport = process.env.MCP_TRANSPORT || 'stdio';
 		console.error('Starling Bank MCP server running on stdio');
 	} else if (transport === 'http') {
 		const app = express();
-		app.use(express.json());
+		app.use(express.json({limit: '20mb'}));
 
 		const httpTransport = new StreamableHTTPServerTransport({
 			sessionIdGenerator: undefined,


### PR DESCRIPTION
## Summary

Express's `express.json()` middleware defaults to a 100KB body size limit, which is too small for base64-encoded receipt/attachment uploads via the `feed_item_attachment_upload` tool. This change bumps the limit to 20MB to accommodate larger payloads.