### PR TITLE
test: update gated e2e test from .dxt to .mcpb

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -135,21 +135,21 @@ describe.each([
 		},
 	},
 	{
-		name: 'DXT Package',
-		condition: process.env.RUN_DXT_TEST,
+		name: 'MCP Bundle',
+		condition: process.env.RUN_MCPB_TEST,
 		async createClient(): Promise<MCPClient> {
-			// Build DXT package if it doesn't exist
-			if (!existsSync('mcp-server.dxt')) {
-				execSync('./build-dxt.sh', {stdio: 'inherit'});
+			// Build MCP Bundle if it doesn't exist
+			if (!existsSync('starling-bank-mcp.mcpb')) {
+				execSync('./build-mcpb.sh', {stdio: 'inherit'});
 			}
 
-			// Extract DXT package to test directory
-			const testDir = 'test-dxt-client';
+			// Extract MCP Bundle to test directory
+			const testDir = 'test-mcpb-client';
 			execSync(`rm -rf ${testDir}`);
-			execSync(`mkdir -p ${testDir} && unzip -q mcp-server.dxt -d ${testDir}`);
+			execSync(`mkdir -p ${testDir} && unzip -q starling-bank-mcp.mcpb -d ${testDir}`);
 
-			// Start the MCP server from the extracted DXT package
-			const serverProcess = spawn('node', [path.join(testDir, 'dist/index.js')], {
+			// Start the MCP server from the extracted MCP Bundle
+			const serverProcess = spawn('node', [path.join(testDir, 'dist/main.js')], {
 				stdio: ['pipe', 'pipe', 'pipe'],
 				env: {...process.env},
 			});


### PR DESCRIPTION
Updates the `RUN_DXT_TEST`-gated e2e test to use the `.mcpb` format and current script/file names (`RUN_MCPB_TEST`, `build-mcpb.sh`, `starling-bank-mcp.mcpb`). Also fixes the entry point (`dist/main.js`, not `dist/index.js`, matching `manifest.json`). The test never runs in CI (gated on the env var), but would fail if anyone set it. Same class of staleness as domdomegg/computer-use-mcp#65/#67.