### PR TITLE
docs: replace install instructions with install-mcp link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,106 +11,16 @@ This is a 3rd party integration, and is not affiliated with Starling Bank.
 
 ## Installation
 
-**Step 1**: Create a Starling Bank personal access token. To do this:
+Follow the up-to-date instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInN0YXJsaW5nLWJhbmstbWNwIl0sIm5hbWUiOiJzdGFybGluZy1iYW5rIiwiZW52Ijp7IlNUQVJMSU5HX0JBTktfQUNDRVNTX1RPS0VOIjoiZXlKaGIuLi4ifX0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
+
+You'll need a Starling Bank personal access token. To create one:
 - [Sign up for a Starling Developers account](https://developer.starlingbank.com/signup)
 - [Link your Starling Bank account to your Starling Developer account](https://developer.starlingbank.com/settings/account)
-- [Create the access token](https://developer.starlingbank.com/personal/token)
-  - The token name can be anything, e.g. 'Starling Bank MCP Server Token'
-  - Select the scopes based on what you want the AI system to be able to access
+- [Create the access token](https://developer.starlingbank.com/personal/token), selecting the scopes based on what you want the AI system to be able to access
 
-Keep the token handy, you'll need it in the next step. It'll probably begin something like `eyJhbGciOiJQUzI1NiIsInppcCI6IkdaSVAifQ.`, and be moderately long.
+Set it as `STARLING_BANK_ACCESS_TOKEN` (replacing the placeholder in the generated config). It'll probably begin something like `eyJhbGciOiJQUzI1NiIsInppcCI6IkdaSVAifQ.`, and be moderately long.
 
-**Step 2**: Follow the instructions below for your preferred client:
-
-- [Claude Desktop](#claude-desktop)
-- [Cursor](#cursor)
-- [Cline](#cline)
-
-**(Optional, Advanced) Step 3**: See [PAYMENT_SIGNING_SETUP.md](./PAYMENT_SIGNING_SETUP.md) if you want to be able to send payments.
-
-### Claude Desktop
-
-#### (Recommended) Alternative: Via manual .mcpb installation
-
-1. Find the latest mcpb build in [the GitHub Actions history](https://github.com/domdomegg/starling-bank-mcp/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
-2. In the 'Artifacts' section, download the `starling-bank-mcp-mcpb` file
-3. Rename the `.zip` file to `.mcpb`
-4. Double-click the `.mcpb` file to open with Claude Desktop
-5. Click "Install" and configure with your API key
-
-#### (Advanced) Alternative: Via JSON configuration
-
-1. Install [Node.js](https://nodejs.org/en/download)
-2. Open Claude Desktop and go to Settings → Developer
-3. Click "Edit Config" to open your `claude_desktop_config.json` file
-4. Add the following configuration to the "mcpServers" section, replacing `eyJhb...` with your API key:
-
-```json
-{
-  "mcpServers": {
-    "starling-bank": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "starling-bank-mcp"
-      ],
-      "env": {
-        "STARLING_BANK_ACCESS_TOKEN": "eyJhb...",
-      }
-    }
-  }
-}
-```
-
-5. Save the file and restart Claude Desktop
-
-### Cursor
-
-#### (Recommended) Via one-click install
-
-1. Click [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=starling-bank-mcp&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMm5weCUyMC15JTIwc3RhcmxpbmctYmFuay1tY3AlMjIlMkMlMjJlbnYlMjIlM0ElN0IlMjJTVEFSTElOR19CQU5LX0FDQ0VTU19UT0tFTiUyMiUzQSUyMmV5SmhiJTIyJTdEJTdE)
-2. Edit your `mcp.json` file to insert your API key
-
-#### (Advanced) Alternative: Via JSON configuration
-
-Create either a global (`~/.cursor/mcp.json`) or project-specific (`.cursor/mcp.json`) configuration file, replacing `eyJhb...` with your API key:
-
-```json
-{
-  "mcpServers": {
-    "starling-bank": {
-      "command": "npx",
-      "args": ["-y", "starling-bank-mcp"],
-      "env": {
-        "STARLING_BANK_ACCESS_TOKEN": "eyJhb..."
-      }
-    }
-  }
-}
-```
-
-### Cline
-
-#### Via JSON configuration
-
-1. Click the "MCP Servers" icon in the Cline extension
-2. Click on the "Installed" tab, then the "Configure MCP Servers" button at the bottom
-3. Add the following configuration to the "mcpServers" section, replacing `eyJhb...` with your API key:
-
-```json
-{
-  "mcpServers": {
-    "starling-bank": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "starling-bank-mcp"],
-      "env": {
-        "STARLING_BANK_ACCESS_TOKEN": "eyJhb..."
-      }
-    }
-  }
-}
-```
+If you want to be able to send payments, also see [PAYMENT_SIGNING_SETUP.md](./PAYMENT_SIGNING_SETUP.md).
 
 ## Advanced: HTTP Transport
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a 3rd party integration, and is not affiliated with Starling Bank.
 
 ## Installation
 
-Follow the up-to-date instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInN0YXJsaW5nLWJhbmstbWNwIl0sIm5hbWUiOiJzdGFybGluZy1iYW5rIiwiZW52Ijp7IlNUQVJMSU5HX0JBTktfQUNDRVNTX1RPS0VOIjoiZXlKaGIuLi4ifX0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
+Follow the instructions on [install-mcp](https://adamjones.me/install-mcp/?config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInN0YXJsaW5nLWJhbmstbWNwIl0sIm5hbWUiOiJzdGFybGluZy1iYW5rIiwiZW52Ijp7IlNUQVJMSU5HX0JBTktfQUNDRVNTX1RPS0VOIjoiZXlKaGIuLi4ifX0=), which generates the right config for your MCP client (Claude Code, Claude Desktop, Cursor, Cline, VS Code, and more).
 
 You'll need a Starling Bank personal access token. To create one:
 - [Sign up for a Starling Developers account](https://developer.starlingbank.com/signup)


### PR DESCRIPTION
Replaces the hand-maintained install instructions with a single link to [install-mcp](https://adamjones.me/install-mcp/) pre-filled for this server, so each client's instructions stay correct without maintaining them here.

Closes domdomegg/computer-use-mcp#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)