### PR TITLE
Return an object for empty non-JSON responses

### DIFF
--- a/src/utils/starling-api.test.ts
+++ b/src/utils/starling-api.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for response parsing, in particular the 204 No Content responses
+ * returned by mutating endpoints.
+ */
+import {createServer, type Server} from 'node:http';
+import type {AddressInfo} from 'node:net';
+import {
+	describe, test, expect, beforeAll, afterAll,
+} from 'vitest';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+	server = createServer((req, res) => {
+		switch (req.url ?? '') {
+			// Mutating endpoints (spending-category / note updates, deletes)
+			// respond 204 with no body and no content-type.
+			case '/no-content': {
+				res.writeHead(204);
+				res.end();
+				break;
+			}
+
+			// Some endpoints return 200 with an empty JSON body.
+			case '/empty-json': {
+				res.writeHead(200, {'content-type': 'application/json'});
+				res.end('');
+				break;
+			}
+
+			case '/json': {
+				res.writeHead(200, {'content-type': 'application/json'});
+				res.end(JSON.stringify({savingsGoalUid: 'abc', success: true}));
+				break;
+			}
+
+			case '/text': {
+				res.writeHead(200, {'content-type': 'text/plain'});
+				res.end('some plain text');
+				break;
+			}
+
+			default: {
+				res.writeHead(404, {'content-type': 'application/json'});
+				res.end(JSON.stringify({error: 'not found'}));
+			}
+		}
+	});
+
+	await new Promise<void>((resolve) => {
+		server.listen(0, '127.0.0.1', resolve);
+	});
+
+	const {port} = server.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+	process.env.STARLING_BANK_BASE_URL = baseUrl;
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolve, reject) => {
+		server.close((error) => {
+			if (error) {
+				reject(error);
+			} else {
+				resolve();
+			}
+		});
+	});
+});
+
+describe('makeStarlingApiCall response parsing', () => {
+	test('returns a success object for 204 No Content', async () => {
+		const {makeStarlingApiCall} = await import('./starling-api.js');
+
+		const result = await makeStarlingApiCall('/no-content', 'test-token', 'PUT', {spendingCategory: 'EXPENSES'});
+
+		// Must be an object: callers validate this against object output
+		// schemas. Returning a bare string here made successful updates fail
+		// validation and be reported as errors, despite having been applied.
+		expect(result).toBeTypeOf('object');
+		expect(result).toEqual({success: true, message: 'Operation completed successfully'});
+	});
+
+	test('returns a success object for an empty JSON body', async () => {
+		const {makeStarlingApiCall} = await import('./starling-api.js');
+
+		const result = await makeStarlingApiCall('/empty-json', 'test-token');
+
+		expect(result).toEqual({success: true, message: 'Operation completed successfully'});
+	});
+
+	test('parses a JSON body', async () => {
+		const {makeStarlingApiCall} = await import('./starling-api.js');
+
+		const result = await makeStarlingApiCall('/json', 'test-token');
+
+		expect(result).toEqual({savingsGoalUid: 'abc', success: true});
+	});
+
+	test('returns non-empty non-JSON bodies as text', async () => {
+		const {makeStarlingApiCall} = await import('./starling-api.js');
+
+		const result = await makeStarlingApiCall('/text', 'test-token');
+
+		expect(result).toBe('some plain text');
+	});
+
+	test('throws on error responses', async () => {
+		const {makeStarlingApiCall} = await import('./starling-api.js');
+
+		await expect(makeStarlingApiCall('/missing', 'test-token')).rejects.toThrow('Starling API error: 404');
+	});
+});

--- a/src/utils/starling-api.ts
+++ b/src/utils/starling-api.ts
@@ -43,7 +43,18 @@ async function parseResponse(response: Response): Promise<unknown> {
 		}
 	}
 
-	return (await response.text()) || 'Success';
+	// Non-JSON responses. Mutating endpoints (e.g. spending-category / note
+	// updates, deletes) reply 204 No Content with no content-type, so there is
+	// no body to return. Callers validate against object output schemas, so
+	// return the same success object as the empty-JSON case rather than a bare
+	// string - otherwise a successful call fails schema validation and is
+	// reported as an error despite the action having been applied.
+	const text = await response.text();
+	if (!text.trim()) {
+		return {success: true, message: 'Operation completed successfully'};
+	}
+
+	return text;
 }
 
 // Function to create message signature for payment endpoints


### PR DESCRIPTION
## Problem

Mutating endpoints (`feed_item_spending_category_update`, `feed_item_note_update`, `savings_goal_delete`, `payee_delete`, and the savings-goal create/update/deposit/withdraw tools when the body is empty) failed with:

```
[{ "expected": "object", "code": "invalid_type", "path": [], "message": "Invalid input: expected object, received string" }]
```

**The action was actually being applied** — only the response validation failed. I confirmed this by retagging feed items and deleting a savings goal: all reported errors, all took effect. That's the dangerous shape of this bug, since a caller may reasonably conclude nothing happened and retry, or report a false failure to the user.

## Cause

Starling replies `204 No Content` (no `content-type` header) to these requests. That falls past the JSON branch of `parseResponse`, reaching:

```js
return (await response.text()) || 'Success';
```

With an empty body this returns the *string* `'Success'`. Every caller then runs `outputSchema.parse(result)` against a Zod **object** schema, which throws. The `"path": []` in the error was the tell — the mismatch is at the root of the value, not on any field, so it was never about the input arguments.

## Fix

Return the same `{success: true, ...}` object that the empty-JSON branch already returns. Non-empty text bodies still pass through as text, and error responses still throw.

## Tests

Adds `src/utils/starling-api.test.ts` — five tests against a local HTTP server covering a real 204, an empty JSON body, normal JSON, plain text, and the error path.

I verified the regression test actually catches the bug: against the previous code it fails with `expected 'Success' to be type of 'object'`, and passes with the fix. Full suite 18 passed / 1 skipped; lint and typecheck clean.

Not verified against the live Starling API (no local access token) — covered by unit test and code inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)